### PR TITLE
Add alternative global composer bin directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installation
     composer global require evert/phpunit-bin
 
 Make sure that after you run that, your global composer `bin` directory is
-in your `$PATH`. This is usually `~/.composer/vendor/bin`.
+in your `$PATH`. This is usually `~/.composer/vendor/bin`, or `~/.config/composer/vendor/bin` 
 
 
 [1]: https://phpunit.de/


### PR DESCRIPTION
In recent versions of composer COMPOSER_HOME may use the `$XDG_CONFIG_HOME` env variable.
See: https://getcomposer.org/doc/03-cli.md#composer-home
