### PR TITLE
Search in current working dir first

### DIFF
--- a/phpunit
+++ b/phpunit
@@ -2,7 +2,7 @@
 <?php
 
 // Traversing up the directory tree to find composer.json
-$projectDir = getcwd();
+$workingDir = $projectDir = getcwd();
 
 while(!file_exists($projectDir . '/composer.json')) {
 
@@ -51,6 +51,13 @@ $testDirs = [
 $phpUnitFile = null;
 
 foreach($testDirs as $testDir) {
+
+    if (file_exists($workingDir . '/' . $testDir)) {
+
+        $phpUnitFile = $workingDir . '/' . $testDir;
+        break;
+
+    }
 
     if (file_exists($projectDir . '/' . $testDir)) {
 


### PR DESCRIPTION
Given my project has a subdirectory containing another testsuite:

```
/tmp/project
├── composer.json
├── phpunit.xml.dist
├── src
├── subproject
│   ├── phpunit.xml.dist
│   ├── src
│   └── tests
└── tests
```

The subproject is should use the `phpunit` binary from the main projects vendor dir.

```
$ cd /tmp/project/subproject
$ phpunit # should run /tmp/project/subproject/phpunit.xml.dist
```
